### PR TITLE
Add WinForms launcher and flag-based game entry

### DIFF
--- a/Project 1/Program.cs
+++ b/Project 1/Program.cs
@@ -1,3 +1,47 @@
-﻿
-using var game = new Project_1.Game1();
-game.Run();
+namespace Project_1;
+
+using System;
+using System.Windows.Forms;
+
+internal static class Program
+{
+    private const string LaunchFlag = "--run-game";
+
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        if (ShouldLaunchGame(args))
+        {
+            using var game = new Game1();
+            game.Run();
+            return;
+        }
+
+#if NET6_0_OR_GREATER
+        ApplicationConfiguration.Initialize();
+#else
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+#endif
+
+        Application.Run(new StartGameForm());
+    }
+
+    private static bool ShouldLaunchGame(string[] args)
+    {
+        if (args == null)
+        {
+            return false;
+        }
+
+        foreach (var arg in args)
+        {
+            if (string.Equals(arg, LaunchFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Project 1/StartGameForm.cs
+++ b/Project 1/StartGameForm.cs
@@ -1,0 +1,78 @@
+namespace Project_1;
+
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+
+public class StartGameForm : Form
+{
+    private readonly Button _startButton;
+
+    public StartGameForm()
+    {
+        Text = "Healer - Launcher";
+        ClientSize = new Size(400, 200);
+        StartPosition = FormStartPosition.CenterScreen;
+        MinimizeBox = true;
+        MaximizeBox = false;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+
+        _startButton = new Button
+        {
+            Text = "Start Game",
+            Anchor = AnchorStyles.None,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Padding = new Padding(20, 10, 20, 10)
+        };
+        _startButton.Click += StartButton_Click;
+
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 1
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        layout.Controls.Add(_startButton, 0, 0);
+
+        Controls.Add(layout);
+    }
+
+    private void StartButton_Click(object? sender, EventArgs e)
+    {
+        _startButton.Enabled = false;
+
+        try
+        {
+            var executablePath = Environment.ProcessPath;
+            if (string.IsNullOrWhiteSpace(executablePath))
+            {
+                executablePath = Application.ExecutablePath;
+            }
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                Arguments = "--run-game",
+                UseShellExecute = true,
+                WorkingDirectory = Environment.CurrentDirectory
+            };
+
+            var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                throw new InvalidOperationException("Unable to start the game process.");
+            }
+
+            Close();
+        }
+        catch (Exception ex)
+        {
+            _startButton.Enabled = true;
+            MessageBox.Show(this, $"Failed to start the game: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the top-level entry point with a Program class that either boots the game or shows a launcher based on a `--run-game` flag
- add a WinForms-based StartGameForm with a centered Start Game button that launches the game in a new process

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1a663128c8331809801e0ef59a68c